### PR TITLE
Cleanup, documentation and comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ authors = [
 [dependencies]
 core = { path = "core/" }
 arrayvec = "0.3"
-cgmath = "0.11.0"
-env_logger = "0.3"
+cgmath = "0.12.0"
+env_logger = "0.4.0"
 error-chain = "0.4"
 glium = "0.15"
-log = "0.3"
+log = "0.3.6"
 num_cpus = "1"
 term-painter = "0.2"
 threadpool = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ authors = [
     "Julian Kniephoff <me@juliankniephoff.com>",
 ]
 
+[workspace]
+
 [dependencies]
 core = { path = "core/" }
 arrayvec = "0.3"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,5 +7,5 @@ authors = [
 ]
 
 [dependencies]
-cgmath = "0.11.0"
+cgmath = "0.12.0"
 rayon = "0.4"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,15 +11,15 @@ pub use shape::Shape;
 // use std::time::Instant;
 
 
-pub fn get_circle(width: usize, height: usize, _angle: f64) -> PixelImage {
+pub fn get_circle(width: usize, height: usize, _angle: f32) -> PixelImage {
 
     let out = PixelImage::from_pixels(width, height, |_, _| {
 
         Color::white()
 
-    //     const WINDOW: f64 = 3.0;
-    //     let origin_x = (x as f64) / (width as f64 / WINDOW) - (WINDOW / 2.0);
-    //     let origin_z = (y as f64) / (height as f64 / WINDOW) - (WINDOW / 2.0);
+    //     const WINDOW: f32 = 3.0;
+    //     let origin_x = (x as f32) / (width as f32 / WINDOW) - (WINDOW / 2.0);
+    //     let origin_z = (y as f32) / (height as f32 / WINDOW) - (WINDOW / 2.0);
     //     // let origin = Point3::new(origin_x, -2.0, origin_z - 1.0);
     //     // let dir = Vector3::new(0.0, 1.0, 0.2);
 
@@ -36,8 +36,8 @@ pub fn get_circle(width: usize, height: usize, _angle: f64) -> PixelImage {
     //         let mut r = 0.0;
 
     //         const MAX_ITERS: u32 = 10;
-    //         const BAILOUT: f64 = 2.5;
-    //         const POWER: f64 = 8.0;
+    //         const BAILOUT: f32 = 2.5;
+    //         const POWER: f32 = 8.0;
 
     //         for i in 0..MAX_ITERS {
 
@@ -48,8 +48,8 @@ pub fn get_circle(width: usize, height: usize, _angle: f64) -> PixelImage {
 
     //             // convert to polar coordinates
     //             let theta = (z.z / r).acos();
-    //             // let theta = f64::atan2((z.x * z.x + z.y * z.y).sqrt(), z.z);
-    //             let phi = f64::atan2(z.y, z.x);
+    //             // let theta = f32::atan2((z.x * z.x + z.y * z.y).sqrt(), z.z);
+    //             let phi = f32::atan2(z.y, z.x);
     //             dr = r.powf(POWER - 1.0) * POWER * dr + 1.0;
 
     //             // scale and rotate the point
@@ -107,8 +107,8 @@ pub fn get_circle(width: usize, height: usize, _angle: f64) -> PixelImage {
 // fn march_ray<E>(origin: Point3f, dir: Vector3f, mut de: E) -> Option<SurfacePoint>
 //     where E: FnMut(Point3f) -> DefaultFloat
 // {
-//     const DISTANCE_THRESHOLD: f64 = 0.001;
-//     const BAILOUT: f64 = 2.5;
+//     const DISTANCE_THRESHOLD: f32 = 0.001;
+//     const BAILOUT: f32 = 2.5;
 //     let dir = dir.normalize();
 
 //     let mut iter = 0;

--- a/core/src/math.rs
+++ b/core/src/math.rs
@@ -22,8 +22,8 @@ pub fn lerp<V, F>(a: V, b: V, t: F) -> V
 }
 
 pub trait LerpFactor: Zero + One + PartialOrd + Sub<Output=Self> {}
-impl LerpFactor for f32 {}
 impl LerpFactor for f64 {}
+impl LerpFactor for f32 {}
 
 pub trait Lerp<F: LerpFactor> {
     fn lerp(self, other: Self, t: F) -> Self;
@@ -39,12 +39,12 @@ macro_rules! impl_lerp {
     }
 }
 
-impl_lerp!(Vector3<f64>, f64);
-impl_lerp!(f64, f64);
-impl_lerp!(Rad<f64>, f64);
+impl_lerp!(Vector3<f32>, f32);
+impl_lerp!(f32, f32);
+impl_lerp!(Rad<f32>, f32);
 
-impl Lerp<f64> for Point3<f64> {
-    fn lerp(self, other: Self, t: f64) -> Self {
+impl Lerp<f32> for Point3<f32> {
+    fn lerp(self, other: Self, t: f32) -> Self {
         self * (1.0 - t) + other.to_vec() * t
     }
 }

--- a/core/src/shape/mandelbulb.rs
+++ b/core/src/shape/mandelbulb.rs
@@ -48,7 +48,7 @@ impl Shape for Mandelbulb {
             z = zr * Point3::new(
                 theta.sin() * phi.cos(),
                 phi.sin() * theta.sin(),
-                theta.cos()
+                theta.cos(),
             );
             z += p.to_vec();
         }
@@ -85,7 +85,7 @@ impl Shape for Mandelbulb {
             z = zr * Point3::new(
                 theta.sin() * phi.cos(),
                 phi.sin() * theta.sin(),
-                theta.cos()
+                theta.cos(),
             );
             z += p.to_vec();
         }

--- a/core/src/shape/mandelbulb.rs
+++ b/core/src/shape/mandelbulb.rs
@@ -5,25 +5,25 @@ use super::{DistanceApprox, Shape};
 pub struct Mandelbulb {
     power: f32,
     max_iters: u64,
+    bailout: f32,
 }
 
 impl Mandelbulb {
-    pub fn new(power: f32, max_iters: u64) -> Self {
+    pub fn new(power: f32, max_iters: u64, bailout: f32) -> Self {
         Mandelbulb {
             power: power,
             max_iters: max_iters,
+            bailout: bailout,
         }
     }
 
-    pub fn classic(max_iters: u64) -> Self {
-        Self::new(8.0, max_iters)
+    pub fn classic(max_iters: u64, bailout: f32) -> Self {
+        Self::new(8.0, max_iters, bailout)
     }
 }
 
 impl Shape for Mandelbulb {
     fn contains(&self, p: Point3<f32>) -> bool {
-        const BAILOUT: f32 = 2.5;
-
         let mut z = p;
 
         for _ in 0..self.max_iters {
@@ -31,7 +31,7 @@ impl Shape for Mandelbulb {
             let r = z.to_vec().magnitude();
 
             // If the radius is bigger than BAILOUT, this point will diverge
-            if r > BAILOUT {
+            if r > self.bailout {
                 return false;
             }
 

--- a/core/src/shape/mandelbulb.rs
+++ b/core/src/shape/mandelbulb.rs
@@ -3,12 +3,12 @@ use super::{DistanceApprox, Shape};
 
 #[derive(Clone)]
 pub struct Mandelbulb {
-    power: f64,
+    power: f32,
     max_iters: u64,
 }
 
 impl Mandelbulb {
-    pub fn new(power: f64, max_iters: u64) -> Self {
+    pub fn new(power: f32, max_iters: u64) -> Self {
         Mandelbulb {
             power: power,
             max_iters: max_iters,
@@ -21,8 +21,8 @@ impl Mandelbulb {
 }
 
 impl Shape for Mandelbulb {
-    fn contains(&self, p: Point3<f64>) -> bool {
-        const BAILOUT: f64 = 2.5;
+    fn contains(&self, p: Point3<f32>) -> bool {
+        const BAILOUT: f32 = 2.5;
 
         let mut z = p;
 
@@ -37,7 +37,7 @@ impl Shape for Mandelbulb {
 
             // Convert to spherical coordinates
             let theta = (z.z / r).acos();
-            let phi = f64::atan2(z.y, z.x);
+            let phi = f32::atan2(z.y, z.x);
 
             // Scale and rotate the point
             let zr = r.powf(self.power);
@@ -58,12 +58,12 @@ impl Shape for Mandelbulb {
         true
     }
 
-    fn distance(&self, p: Point3<f64>) -> DistanceApprox {
+    fn distance(&self, p: Point3<f32>) -> DistanceApprox {
         let mut z = p;
         let mut dr = 1.0;
         let mut r = 0.0;
 
-        const BAILOUT: f64 = 2.5;
+        const BAILOUT: f32 = 2.5;
 
         for _ in 0..self.max_iters {
             r = z.to_vec().magnitude();
@@ -73,7 +73,7 @@ impl Shape for Mandelbulb {
 
             // convert to polar coordinates
             let theta = (z.z / r).acos();
-            let phi = f64::atan2(z.y, z.x);
+            let phi = f32::atan2(z.y, z.x);
             dr = r.powf(self.power - 1.0) * self.power * dr + 1.0;
 
             // scale and rotate the point

--- a/core/src/shape/mod.rs
+++ b/core/src/shape/mod.rs
@@ -1,22 +1,25 @@
-use math::*;
+    use math::*;
 
 mod sphere;
 mod mandelbulb;
 
-pub use self::sphere::*;
-pub use self::mandelbulb::*;
+pub use self::sphere::Sphere;
+pub use self::mandelbulb::Mandelbulb;
 
+#[derive(Clone, Copy, Debug)]
 pub struct DistanceApprox {
     pub min: f64,
     pub max: f64,
 }
 
 pub trait Shape: Send {
-    fn contains(&self, p: Point3<f64>) -> bool;
-
-    /// Returns the estimated distance from `p` to the closest surface point.
-    /// If `p` is inside the shape, the same applies, but the returned distance
-    /// has to be negative. `0.0` may be returned, this function mustn't
-    /// return `-0.0`.
+    /// Returns an estimate for the distance from `p` to the closest surface
+    /// point of the shape.
+    ///
+    /// If `p` is inside the shape, the returned distance has to be negative.
+    /// Either both or none of `min` and `max` have to be negative.
     fn distance(&self, p: Point3<f64>) -> DistanceApprox;
+
+    /// Returns true iff the given point lies in the shape.
+    fn contains(&self, p: Point3<f64>) -> bool;
 }

--- a/core/src/shape/mod.rs
+++ b/core/src/shape/mod.rs
@@ -1,4 +1,4 @@
-    use math::*;
+use math::*;
 
 mod sphere;
 mod mandelbulb;

--- a/core/src/shape/mod.rs
+++ b/core/src/shape/mod.rs
@@ -8,8 +8,8 @@ pub use self::mandelbulb::Mandelbulb;
 
 #[derive(Clone, Copy, Debug)]
 pub struct DistanceApprox {
-    pub min: f64,
-    pub max: f64,
+    pub min: f32,
+    pub max: f32,
 }
 
 pub trait Shape: Send {
@@ -18,8 +18,8 @@ pub trait Shape: Send {
     ///
     /// If `p` is inside the shape, the returned distance has to be negative.
     /// Either both or none of `min` and `max` have to be negative.
-    fn distance(&self, p: Point3<f64>) -> DistanceApprox;
+    fn distance(&self, p: Point3<f32>) -> DistanceApprox;
 
     /// Returns true iff the given point lies in the shape.
-    fn contains(&self, p: Point3<f64>) -> bool;
+    fn contains(&self, p: Point3<f32>) -> bool;
 }

--- a/core/src/shape/sphere.rs
+++ b/core/src/shape/sphere.rs
@@ -17,6 +17,7 @@ impl Sphere {
 }
 
 impl Shape for Sphere {
+    // Overwrite default method for performance
     fn contains(&self, p: Point3<f64>) -> bool {
         (self.center - p).magnitude2() <= (self.radius * self.radius)
     }

--- a/core/src/shape/sphere.rs
+++ b/core/src/shape/sphere.rs
@@ -3,12 +3,12 @@ use super::{DistanceApprox, Shape};
 
 #[derive(Clone)]
 pub struct Sphere {
-    center: Point3<f64>,
-    radius: f64,
+    center: Point3<f32>,
+    radius: f32,
 }
 
 impl Sphere {
-    pub fn new(center: Point3<f64>, radius: f64) -> Self {
+    pub fn new(center: Point3<f32>, radius: f32) -> Self {
         Sphere {
             center: center,
             radius: radius,
@@ -18,11 +18,11 @@ impl Sphere {
 
 impl Shape for Sphere {
     // Overwrite default method for performance
-    fn contains(&self, p: Point3<f64>) -> bool {
+    fn contains(&self, p: Point3<f32>) -> bool {
         (self.center - p).magnitude2() <= (self.radius * self.radius)
     }
 
-    fn distance(&self, p: Point3<f64>) -> DistanceApprox {
+    fn distance(&self, p: Point3<f32>) -> DistanceApprox {
         let d = (self.center - p).magnitude() - self.radius;
         DistanceApprox {
             min: d,

--- a/shader/iso-surface.frag
+++ b/shader/iso-surface.frag
@@ -1,5 +1,7 @@
 #version 140
 
+// INCLUDE(DE)
+
 in float dist;
 in float z;
 in vec3 world_pos;

--- a/shader/iso-surface.vert
+++ b/shader/iso-surface.vert
@@ -15,8 +15,8 @@ void main() {
     world_pos = position;
 
     gl_Position = vec4(
-        proj_matrix *
-        view_matrix *
-        vec4(position, 1.0)
+        proj_matrix
+            * view_matrix
+            * vec4(position, 1.0)
     );
 }

--- a/shader/point-cloud-mandelbulb.frag
+++ b/shader/point-cloud-mandelbulb.frag
@@ -1,13 +1,15 @@
 #version 140
 
-in vec3 ocolor;
+in float dist;
 in float z;
 in vec3 world_pos;
 
 out vec4 color;
 
-void main() {
-    float c = abs(1.0 - length(world_pos)) * 1000;
+float col() {
+    return pow(length(world_pos) * 0.85, 8.0) * 0.7;
+}
 
-    color = vec4(ocolor, 1.0);
+void main() {
+    color = vec4(vec3(col()), 1.0);
 }

--- a/shader/point-cloud-mandelbulb.vert
+++ b/shader/point-cloud-mandelbulb.vert
@@ -1,6 +1,6 @@
 #version 400
-uniform dmat4 view_matrix;
-uniform dmat4 proj_matrix;
+uniform mat4 view_matrix;
+uniform mat4 proj_matrix;
 
 out float z;
 out float dist;

--- a/shader/point-cloud-mandelbulb.vert
+++ b/shader/point-cloud-mandelbulb.vert
@@ -3,15 +3,15 @@ uniform dmat4 view_matrix;
 uniform dmat4 proj_matrix;
 
 out float z;
-out vec3 ocolor;
+out float dist;
 out vec3 world_pos;
 
 in vec3 position;
-in vec3 color;
+in float distance_from_surface;
 
 void main() {
     z = position.z;
-    ocolor = color;
+    dist = distance_from_surface;
     world_pos = position;
 
     gl_Position = vec4(

--- a/src/app.rs
+++ b/src/app.rs
@@ -56,6 +56,7 @@ impl App {
         use std::time::{Duration, Instant};
         use std::io::{self, Write};
 
+        // Code for printing FPS and frame time
         const PRINT_FPS_EVERY_MS: u64 = 200;
         let mut next_fps_print_in = Duration::from_millis(PRINT_FPS_EVERY_MS);
         let mut frame_count = 0;
@@ -123,7 +124,7 @@ impl App {
         let mut new_res = None;
         let print_fps = &mut self.print_fps;
 
-        let out = poll_events_with(&self.facade, vec![
+        let out = poll_events_with(&self.facade, &mut [
             self.control.as_event_handler(),
             &mut QuitHandler,
             &mut |e: &Event| {

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,13 +25,12 @@ impl App {
         use glium::glutin::VirtualKeyCode;
 
         // Create OpenGL context
-        let facade = try!(
-            create_context().chain_err(|| "failed to create GL context")
-        );
+        let facade = create_context()
+            .chain_err(|| "failed to create GL context")?;
 
         let shape = Mandelbulb::classic(20);
         // let shape = Sphere::new(Point3::new(0.0, 0.0, 0.0), 1.0);
-        let mesh = try!(FractalMesh::new(&facade, shape));
+        let mesh = FractalMesh::new(&facade, shape)?;
 
         let proj = Projection::new(
             Rad(1.0),
@@ -68,7 +67,7 @@ impl App {
 
             // Approximate time since last iteration and update all components
             let delta = Instant::now() - last_time;
-            let delta_sec = (delta.subsec_nanos() / 1000) as f64 / 1_000_000.0;
+            let delta_sec = (delta.subsec_nanos() / 1000) as f32 / 1_000_000.0;
 
             self.control.update(delta_sec, self.mesh.shape());
             self.mesh.update(&self.facade, &self.control.camera());
@@ -99,9 +98,9 @@ impl App {
                 if delta >= next_fps_print_in {
                     let over_time = delta - next_fps_print_in;
                     let since_last = over_time + Duration::from_millis(PRINT_FPS_EVERY_MS);
-                    let since_last = (since_last.subsec_nanos() / 1000) as f64 / 1000.0;
+                    let since_last = (since_last.subsec_nanos() / 1000) as f32 / 1000.0;
 
-                    let avg_delta = since_last / (frame_count as f64);
+                    let avg_delta = since_last / (frame_count as f32);
 
                     print!("\rδ {:.3}ms ({:.3} FPS)", avg_delta, 1000.0 / avg_delta);
                     io::stdout().flush().expect("flushing stdout failed...");
@@ -176,9 +175,7 @@ fn create_context() -> Result<GlutinFacade> {
         .with_dimensions(monitor_width / 2, monitor_height / 2)
         .with_title(WINDOW_TITLE)
         .with_gl(GlRequest::Latest)
-        .build_glium();
-
-    let context = try!(context);
+        .build_glium()?;
 
     // Print some information about the acquired OpenGL context
     info!("OpenGL context was successfully built");

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,7 +28,7 @@ impl App {
         let facade = create_context()
             .chain_err(|| "failed to create GL context")?;
 
-        let shape = Mandelbulb::classic(20);
+        let shape = Mandelbulb::classic(5, 2.5);
         // let shape = Sphere::new(Point3::new(0.0, 0.0, 0.0), 1.0);
         let mesh = FractalMesh::new(&facade, shape)?;
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -6,15 +6,15 @@ use cgmath;
 /// direction vector must never be linear dependent to the up-vector, we have
 /// limit the possible values theta can take. This is the "safe zone" that theta
 /// must never be in; specifically '0...epsilon' and '(pi - epsilon)...pi'
-const THETA_SAFE_EPSILON: Rad<f64> = Rad(0.02);
+const THETA_SAFE_EPSILON: Rad<f32> = Rad(0.02);
 
 
 /// Saves the camera position and look direction as well as projection
 /// parameters.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Camera {
-    pub position: Point3<f64>,
-    direction: Vector3<f64>,
+    pub position: Point3<f32>,
+    direction: Vector3<f32>,
     pub projection: Projection,
 }
 
@@ -22,7 +22,7 @@ impl Camera {
     /// Creates a new instance.
     ///
     /// `dir` mustn't be zero.
-    pub fn new(pos: Point3<f64>, dir: Vector3<f64>, proj: Projection) -> Self {
+    pub fn new(pos: Point3<f32>, dir: Vector3<f32>, proj: Projection) -> Self {
         assert!(!dir.is_zero());
 
         Camera {
@@ -34,13 +34,13 @@ impl Camera {
 
     /// Returns the spherical coordinates of the direction vector as
     /// `(theta, phi)`.
-    pub fn spherical_coords(&self) -> (Rad<f64>, Rad<f64>) {
+    pub fn spherical_coords(&self) -> (Rad<f32>, Rad<f32>) {
         let d = self.direction;
-        (Rad(d.z.acos()), Rad(f64::atan2(d.y, d.x)))
+        (Rad(d.z.acos()), Rad(f32::atan2(d.y, d.x)))
     }
 
     /// Sets the normalized, given vector as new direction vector.
-    pub fn look_in(&mut self, dir: Vector3<f64>) {
+    pub fn look_in(&mut self, dir: Vector3<f32>) {
         self.direction = dir.normalize();
 
         let (theta, phi) = self.spherical_coords();
@@ -49,14 +49,14 @@ impl Camera {
     }
 
     /// Clamps theta into the allowed range
-    fn clamp_theta(theta: Rad<f64>) -> Rad<f64> {
-        use std::f64::consts::PI;
+    fn clamp_theta(theta: Rad<f32>) -> Rad<f32> {
+        use std::f32::consts::PI;
 
         clamp(theta, THETA_SAFE_EPSILON, Rad(PI) - THETA_SAFE_EPSILON)
     }
 
     /// Sets the direction vector from the given spherical coordinates
-    pub fn look_at_sphere(&mut self, theta: Rad<f64>, phi: Rad<f64>) {
+    pub fn look_at_sphere(&mut self, theta: Rad<f32>, phi: Rad<f32>) {
         let theta = Self::clamp_theta(theta);
 
         self.direction = Vector3::new(
@@ -67,12 +67,12 @@ impl Camera {
     }
 
     /// Returns the current direction vector. It's guaranteed to be normalized.
-    pub fn direction(&self) -> Vector3<f64> {
+    pub fn direction(&self) -> Vector3<f32> {
         self.direction
     }
 
     /// Returns the matrix representing the transformation into view space.
-    pub fn view_transform(&self) -> Matrix4<f64> {
+    pub fn view_transform(&self) -> Matrix4<f32> {
         Matrix4::look_at(
             self.position,
             self.position + self.direction,
@@ -82,7 +82,7 @@ impl Camera {
 
     /// Returns the matrix representing the transformation into projection
     /// space.
-    pub fn proj_transform(&self) -> Matrix4<f64> {
+    pub fn proj_transform(&self) -> Matrix4<f32> {
         self.projection.transformation_matrix()
     }
 }
@@ -92,17 +92,17 @@ impl Camera {
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Projection {
     /// Field of view in the y direction (in range [0, π/2]).
-    pub fov: Rad<f64>,
+    pub fov: Rad<f32>,
 
     /// Ratio between the width and the height. The field of view in the x
     /// direction is `self.fov * aspect_ratio`.
-    aspect_ratio: f64,
+    aspect_ratio: f32,
 
     /// Everything closer to the camera than this won't be rendered.
-    pub near_plane: f64,
+    pub near_plane: f32,
 
     /// Everything farther away from the camera than this won't be rendered.
-    pub far_plane: f64,
+    pub far_plane: f32,
 }
 
 impl Projection {
@@ -111,12 +111,12 @@ impl Projection {
     /// The `proj_range` reflects the near and far plane for projection. The
     /// aspect ratio is calculated from the given screen dimension, which has
     /// to be non-zero in both axes.
-    pub fn new(fov: Rad<f64>, proj_range: Range<f64>, (w, h): (u32, u32)) -> Self {
+    pub fn new(fov: Rad<f32>, proj_range: Range<f32>, (w, h): (u32, u32)) -> Self {
         assert!(w > 0 && h > 0, "given screen dimension {:?} musn't be zero", (w, h));
 
         Projection {
             fov: fov,
-            aspect_ratio: (w as f64) / (h as f64),
+            aspect_ratio: (w as f32) / (h as f32),
             near_plane: proj_range.start,
             far_plane: proj_range.end,
         }
@@ -131,7 +131,7 @@ impl Projection {
             (width, height)
         );
 
-        self.aspect_ratio = (width as f64) / (height as f64);
+        self.aspect_ratio = (width as f32) / (height as f32);
     }
 
     /// Sets the aspect ratio to the aspect ratio of `other`
@@ -145,8 +145,8 @@ impl Projection {
     /// The field of view needs to be in between 0 and π/2. Both, near and far
     /// plane have to be greater than zero and the near plane has to be less
     /// than the far plane.
-    pub fn transformation_matrix(&self) -> Matrix4<f64> {
-        use std::f64::consts::FRAC_PI_2;
+    pub fn transformation_matrix(&self) -> Matrix4<f32> {
+        use std::f32::consts::FRAC_PI_2;
 
         assert!(self.fov > Rad(0.0));
         assert!(self.fov < Rad(FRAC_PI_2));

--- a/src/control/fly.rs
+++ b/src/control/fly.rs
@@ -8,32 +8,32 @@ use super::CamControl;
 
 /// This describes the maximum speed (per seconds) in which the camera can fly
 /// around
-const MAX_MOVE_SPEED: f64 = 1.0;
+const MAX_MOVE_SPEED: f32 = 1.0;
 
 /// This describes how slowly the maximum speed is reached. Precisely, it's
 /// the time (in seconds) it takes to accelerate from speed 'x' to speed
 /// '(MAX_MOVE_SPEED + x) / 2'.
-const MOVE_DELAY: f64 = 0.05;
+const MOVE_DELAY: f32 = 0.05;
 
 /// How much faster the move speed is when going into fast mode.
-const FAST_MOVE_MULTIPLIER: f64 = 3.0;
+const FAST_MOVE_MULTIPLIER: f32 = 3.0;
 
 /// Describes how much the angle of the look at vector is changed, when the
 /// mouse moves one pixel. This is doubled for phi, as its range is twice as
 /// big.
-const TURN_PER_PIXEL: Rad<f64> = Rad(0.0015);
+const TURN_PER_PIXEL: Rad<f32> = Rad(0.0015);
 
 pub struct Fly {
     cam: Camera,
 
     facade: GlutinFacade,
 
-    forward_speed: f64,
-    forward_accel: f64,
-    left_speed: f64,
-    left_accel: f64,
-    up_speed: f64,
-    up_accel: f64,
+    forward_speed: f32,
+    forward_accel: f32,
+    left_speed: f32,
+    left_accel: f32,
+    up_speed: f32,
+    up_accel: f32,
     faster: bool,
 }
 
@@ -78,12 +78,12 @@ impl CamControl for Fly {
         &mut self.cam.projection
     }
 
-    fn update(&mut self, delta: f64, shape: &Shape) {
-        fn update_speed(speed: &mut f64, accel: f64, delta: f64) {
+    fn update(&mut self, delta: f32, shape: &Shape) {
+        fn update_speed(speed: &mut f32, accel: f32, delta: f32) {
             *speed = lerp(
                 *speed,
                 accel * MAX_MOVE_SPEED,
-                (1.0 - 2.0f64.powf(-delta / MOVE_DELAY)),
+                (1.0 - 2.0f32.powf(-delta / MOVE_DELAY)),
             );
         }
 
@@ -182,8 +182,8 @@ impl EventHandler for Fly {
                 let (x_diff, y_diff) = (x - (x_center as i32), y - (y_center as i32));
 
                 let (mut theta, mut phi) = self.cam.spherical_coords();
-                theta += TURN_PER_PIXEL * (y_diff as f64);
-                phi += TURN_PER_PIXEL * 2.0 * (-x_diff as f64);
+                theta += TURN_PER_PIXEL * (y_diff as f32);
+                phi += TURN_PER_PIXEL * 2.0 * (-x_diff as f32);
 
                 self.cam.look_at_sphere(theta, phi);
 

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -24,7 +24,7 @@ pub trait CamControl: EventHandler {
 
     /// Is called regularly to update the internal camera. `delta` is the time
     /// in seconds since the last time this method was called.
-    fn update(&mut self, _delta: f64, _shape: &Shape) {}
+    fn update(&mut self, _delta: f32, _shape: &Shape) {}
 
     /// Returns `self` as `EventHandler` trait object.
     fn as_event_handler(&mut self) -> &mut EventHandler;
@@ -52,7 +52,7 @@ pub struct KeySwitcher<A, B> {
 
     /// How much the first camera influences the final camera (between 1.0
     /// and 0.0).
-    amount_first: f64,
+    amount_first: f32,
 }
 
 impl<A: CamControl, B: CamControl> KeySwitcher<A, B> {
@@ -131,8 +131,8 @@ impl<A: CamControl, B: CamControl> CamControl for KeySwitcher<A, B> {
         }
     }
 
-    fn update(&mut self, delta: f64, shape: &Shape) {
-        const TRANSITION_DURATION: f64 = 0.3;
+    fn update(&mut self, delta: f32, shape: &Shape) {
+        const TRANSITION_DURATION: f32 = 0.3;
 
         self.amount_first += (delta / TRANSITION_DURATION) * if self.first_active {
             1.0

--- a/src/control/orbit.rs
+++ b/src/control/orbit.rs
@@ -7,43 +7,43 @@ use super::CamControl;
 
 /// This describes the maximum speed (per seconds) in which theta can change.
 /// Phi can change twice as fast, because the range is twice as big.
-const MAX_TURN_SPEED: Rad<f64> = Rad(1.0);
+const MAX_TURN_SPEED: Rad<f32> = Rad(1.0);
 
 /// This describes how slowly the maximum speed is reached. Precisely, it's
 /// the time (in seconds) it takes to accelerate from speed 'x' to speed
 /// '(MAX_TURN_SPEED + x) / 2'.
-const TURN_DELAY: f64 = 0.05;
+const TURN_DELAY: f32 = 0.05;
 
 /// Describes how quickly the user can zoom in and out. Precisely,
 /// '2.pow(ZOOM_SPEED)' describes the factor by which the distance can grow
 /// or shrink each second. When ZOOM_SPEED=1.0 (default), then the distance
 /// doubles or shrinks every second when zooming.
-const ZOOM_SPEED: f64 = 1.0;
+const ZOOM_SPEED: f32 = 1.0;
 
 /// Offers orbital control around a fixed origin point.
 pub struct Orbit {
-    origin: Point3<f64>,
-    distance: f64,  // TODO: this can be calculated from the camera as well ...
+    origin: Point3<f32>,
+    distance: f32,  // TODO: this can be calculated from the camera as well ...
     cam: Camera,
 
     // These four values are used for smooth rotations. The `speed` values
     // hold the current speed (in rad/s) by which the spherical coordinates
     // change the next frame. The `accel` values are either 1, 0 or -1 and
     // described the acceleration by which the speed changes.
-    theta_speed: Rad<f64>,
-    theta_accel: Rad<f64>,
-    phi_speed: Rad<f64>,
-    phi_accel: Rad<f64>,
+    theta_speed: Rad<f32>,
+    theta_accel: Rad<f32>,
+    phi_speed: Rad<f32>,
+    phi_accel: Rad<f32>,
 
     // This is either `ZOOM_SPEED`, 0 or `-ZOOM_SPEED`. See its documentation
     // for more information.
-    zoom_speed: f64,
+    zoom_speed: f32,
 }
 
 impl Orbit {
     /// Creates an orbital control around the given point with the given
     /// projection.
-    pub fn around(origin: Point3<f64>, proj: Projection) -> Self {
+    pub fn around(origin: Point3<f32>, proj: Projection) -> Self {
         let init_dir = Vector3::new(1.0, 0.0, 0.0).normalize();
         let distance = 3.0;
 
@@ -59,7 +59,7 @@ impl Orbit {
         }
     }
 
-    fn update_distance(&mut self, distance: f64) {
+    fn update_distance(&mut self, distance: f32) {
         self.distance = distance;
         self.cam.position = self.origin + self.distance * -self.cam.direction();
     }
@@ -74,17 +74,17 @@ impl CamControl for Orbit {
         &mut self.cam.projection
     }
 
-    fn update(&mut self, delta: f64, _: &Shape) {
+    fn update(&mut self, delta: f32, _: &Shape) {
         // Update the theta and phi turning speeds
         self.theta_speed = lerp(
             self.theta_speed,
             self.theta_accel * MAX_TURN_SPEED.0,
-            (1.0 - 2.0f64.powf(-delta / TURN_DELAY)),
+            (1.0 - 2.0f32.powf(-delta / TURN_DELAY)),
         );
         self.phi_speed = lerp(
             self.phi_speed,
             self.phi_accel * MAX_TURN_SPEED.0 * 2.0,
-            (1.0 - 2.0f64.powf(-delta / TURN_DELAY)),
+            (1.0 - 2.0f32.powf(-delta / TURN_DELAY)),
         );
 
         // Update actual turning position with those calculates speeds and
@@ -98,7 +98,7 @@ impl CamControl for Orbit {
 
         // Update distance from origin
         let rate_of_change = self.zoom_speed * delta;
-        let new_distance = self.distance * 2.0f64.powf(rate_of_change);
+        let new_distance = self.distance * 2.0f32.powf(rate_of_change);
         self.update_distance(new_distance);
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -4,26 +4,23 @@ use glium::glutin::Event;
 
 /// Every event receiver has to return a response for each event received.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[allow(dead_code)]
 pub enum EventResponse {
-    /// The event was not handled at all
+    /// The event was not handled at all.
     NotHandled,
-    /// The event was handled but should be forwarded to other receivers, too
+    /// The event was handled but should be forwarded to other receivers, too.
     Continue,
-    /// The event was handled and should *not* be forwarded to other receivers
+    /// The event was handled and should *not* be forwarded to other receivers.
     Break,
-    /// In response to the event, the program should terminate
+    /// In response to the event, the program should terminate.
     Quit,
 }
 
-/// Ability to handle and reacto to certain input events.
+/// Ability to handle and react to to certain input events.
 pub trait EventHandler {
     fn handle_event(&mut self, e: &Event) -> EventResponse;
 }
 
-impl<F> EventHandler for F where
-    F: FnMut(&Event) -> EventResponse
-{
+impl<F: FnMut(&Event) -> EventResponse> EventHandler for F {
     fn handle_event(&mut self, e: &Event) -> EventResponse {
         self(e)
     }
@@ -44,16 +41,21 @@ impl EventHandler for QuitHandler {
     }
 }
 
-pub fn poll_events_with(facade: &GlutinFacade, mut handlers: Vec<&mut EventHandler>)
-    -> EventResponse
-{
-    let mut handled_one  = false;
+// Given a list of event handlers, pull new events from the window and let
+// the handlers handle those events.
+pub fn poll_events_with(
+    facade: &GlutinFacade,
+    handlers: &mut [&mut EventHandler]
+) -> EventResponse {
+    // We need to check if we handled at least one event
+    let mut handled_at_least_one = false;
+
     for ev in facade.poll_events() {
-        for i in 0..handlers.len() {
-            let response = handlers[i].handle_event(&ev);
+        for handler in handlers.iter_mut() {
+            let response = handler.handle_event(&ev);
 
             if response != EventResponse::NotHandled {
-                handled_one  = true;
+                handled_at_least_one = true;
             }
 
             match response {
@@ -64,7 +66,7 @@ pub fn poll_events_with(facade: &GlutinFacade, mut handlers: Vec<&mut EventHandl
         }
     }
 
-    if handled_one {
+    if handled_at_least_one {
         EventResponse::Continue
     } else {
         EventResponse::NotHandled

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+// We apparently need this for `error-chain`
 #![recursion_limit = "1024"]
 
 #[macro_use] extern crate error_chain;

--- a/src/mesh/buffer.rs
+++ b/src/mesh/buffer.rs
@@ -26,7 +26,7 @@ impl MeshBuffer {
 
         // adjust span to avoid empty transitions
         let mut span = span.clone();
-        let overflow = (span.end - span.start) / resolution as f64;
+        let overflow = (span.end - span.start) / resolution as f32;
         span.start += -overflow;
         span.end += overflow;
         let span = span;
@@ -34,7 +34,7 @@ impl MeshBuffer {
         trace!("Starting to generate in {:?} @ {} res", span, resolution);
 
         let grid = GridTable::fill_with(resolution + 1, |x, y, z| {
-            let v = Vector3::new(x, y, z).cast::<f64>() / (resolution as f64);
+            let v = Vector3::new(x, y, z).cast::<f32>() / (resolution as f32);
             let p = span.start + (span.end - span.start).mul_element_wise(v);
 
             shape.distance(p).min
@@ -46,9 +46,9 @@ impl MeshBuffer {
         // Iterate over all cells of the grid
         let points = GridTable::fill_with(resolution, |x, y, z| {
             // Calculate the corresponding point in world space
-            let v = Vector3::new(x, y, z).cast::<f64>() / (resolution as f64);
+            let v = Vector3::new(x, y, z).cast::<f32>() / (resolution as f32);
             let p0 = span.start + (span.end - span.start).mul_element_wise(v);
-            let step = (span.end - span.start) / resolution as f64;
+            let step = (span.end - span.start) / resolution as f32;
 
             let corners = [
                 p0 + Vector3::new(   0.0,    0.0,    0.0),

--- a/src/mesh/buffer.rs
+++ b/src/mesh/buffer.rs
@@ -1,12 +1,19 @@
 use core::math::*;
 use core::Shape;
-use glium::backend::Facade;
-use glium::index::PrimitiveType;
-use glium::{VertexBuffer, IndexBuffer};
 use mesh::octree::Span;
-use std::ops::Index;
 use util::ToArr;
 use util::iter::cube;
+use util::grid::GridTable;
+
+
+#[derive(Copy, Clone)]
+pub struct Vertex {
+    position: [f32; 3],
+    distance_from_surface: f32,
+}
+
+implement_vertex!(Vertex, position, distance_from_surface);
+
 
 pub struct MeshBuffer {
     raw_vbuf: Vec<Vertex>,
@@ -23,17 +30,45 @@ impl MeshBuffer {
         assert!(span.start.x < span.end.x);
         assert!(span.start.y < span.end.y);
         assert!(span.start.z < span.end.z);
+        assert!(resolution != 0);
 
-        // adjust span to avoid empty transitions
-        let mut span = span.clone();
-        let overflow = (span.end - span.start) / resolution as f32;
-        span.start += -overflow;
-        span.end += overflow;
-        let span = span;
+        Self::naive_surface_nets(span, shape, resolution)
+    }
+
+    /// Implementation of the "Surface Nets" algorithm.
+    ///
+    /// In particular, in this implementation the position of the vertex inside
+    /// the 3D-cell is simply the centroid of all edge crossings. This rather
+    /// easy version is described [in this article][1] ("naive surface nets").
+    ///
+    /// The article will also help understand this algorithm. Compared to
+    /// other algorithms for rendering iso surfaces, this one is relatively
+    /// easy to implement while still working fairly nice.
+    ///
+    /// In the future we might want to switch to the "Dual Contouring" scheme
+    /// as it preserves sharp features of the shape (see #2).
+    ///
+    /// [1]: https://0fps.net/2012/07/12/smooth-voxel-terrain-part-2/
+    fn naive_surface_nets<S: Shape>(
+        span: &Span,
+        shape: &S,
+        resolution: u32,
+    ) -> Self {
+        // Adjust span to avoid holes in between two boxes
+        let span = {
+            let overflow = (span.end - span.start) / resolution as f32;
+            span.start + -overflow .. span.end + overflow
+        };
 
         trace!("Starting to generate in {:?} @ {} res", span, resolution);
 
-        let grid = GridTable::fill_with(resolution + 1, |x, y, z| {
+        // First Step:
+        // ===========
+        //
+        // We partition our box into regular cells. For each corner in between
+        // the cells we calculate and save the estimated minimal distance from
+        // the shape.
+        let dists = GridTable::fill_with(resolution + 1, |x, y, z| {
             let v = Vector3::new(x, y, z).cast::<f32>() / (resolution as f32);
             let p = span.start + (span.end - span.start).mul_element_wise(v);
 
@@ -41,138 +76,226 @@ impl MeshBuffer {
         });
 
 
+        // Second Step:
+        // ============
+        //
+        // Next, we will iterate over all cells of the box (unlike before
+        // where we iterated over corners). For each cell crossing the shape's
+        // surface, we will generate one vertex. The `points` grid table holds
+        // the index of the vertex corresponding to the cell, or `None` if the
+        // cell does not cross the surface.
+        //
         let mut raw_vbuf = Vec::new();
-
-        // Iterate over all cells of the grid
         let points = GridTable::fill_with(resolution, |x, y, z| {
-            // Calculate the corresponding point in world space
-            let v = Vector3::new(x, y, z).cast::<f32>() / (resolution as f32);
-            let p0 = span.start + (span.end - span.start).mul_element_wise(v);
-            let step = (span.end - span.start) / resolution as f32;
+            // Calculate the position of all eight corners of the current cell
+            // in world space. The term "lower corner" describes the corner
+            // with the lowest x, y and z coordinates.
+            let corners = {
+                // The world space distance between two corners/between the
+                // center points of two cells.
+                let step = (span.end - span.start) / resolution as f32;
 
-            let corners = [
-                p0 + Vector3::new(   0.0,    0.0,    0.0),
-                p0 + Vector3::new(   0.0,    0.0, step.z),
-                p0 + Vector3::new(   0.0, step.y,    0.0),
-                p0 + Vector3::new(   0.0, step.y, step.z),
-                p0 + Vector3::new(step.x,    0.0,    0.0),
-                p0 + Vector3::new(step.x,    0.0, step.z),
-                p0 + Vector3::new(step.x, step.y,    0.0),
-                p0 + Vector3::new(step.x, step.y, step.z),
-            ];
+                // World position of this cell's lower corner
+                let p0 = span.start
+                    + Vector3::new(x, y, z).cast::<f32>().mul_element_wise(step);
 
+                [
+                    p0 + Vector3::new(   0.0,    0.0,    0.0),
+                    p0 + Vector3::new(   0.0,    0.0, step.z),
+                    p0 + Vector3::new(   0.0, step.y,    0.0),
+                    p0 + Vector3::new(   0.0, step.y, step.z),
+                    p0 + Vector3::new(step.x,    0.0,    0.0),
+                    p0 + Vector3::new(step.x,    0.0, step.z),
+                    p0 + Vector3::new(step.x, step.y,    0.0),
+                    p0 + Vector3::new(step.x, step.y, step.z),
+                ]
+            };
+
+            // The estimated minimal distances of all eight corners calculated
+            // in the prior step.
             let distances = [
-                grid[(x    , y    , z    )],
-                grid[(x    , y    , z + 1)],
-                grid[(x    , y + 1, z    )],
-                grid[(x    , y + 1, z + 1)],
-                grid[(x + 1, y    , z    )],
-                grid[(x + 1, y    , z + 1)],
-                grid[(x + 1, y + 1, z    )],
-                grid[(x + 1, y + 1, z + 1)],
+                dists[(x    , y    , z    )],
+                dists[(x    , y    , z + 1)],
+                dists[(x    , y + 1, z    )],
+                dists[(x    , y + 1, z + 1)],
+                dists[(x + 1, y    , z    )],
+                dists[(x + 1, y    , z + 1)],
+                dists[(x + 1, y + 1, z    )],
+                dists[(x + 1, y + 1, z + 1)],
             ];
 
+            // First, check if the current cell is only partially inside the
+            // shape (if the cell intersects the shape's surface). If that's
+            // not the case, we won't generate a vertex for this cell.
             let partially_in = !(
                 distances.iter().all(|&d| d < 0.0) ||
                 distances.iter().all(|&d| d > 0.0)
             );
 
-            if partially_in {
-                let edge_ids = [
-                    // in +x direciton
-                    (0, 4),
-                    (1, 5),
-                    (2, 6),
-                    (3, 7),
-
-                    // in +y direction
-                    (0, 2),
-                    (1, 3),
-                    (4, 6),
-                    (5, 7),
-
-                    // in +z direction
-                    (0, 1),
-                    (2, 3),
-                    (4, 5),
-                    (6, 7),
-                ];
-
-                let points: Vec<_> = edge_ids.iter()
-                    // we are only interested in the edges with shape crossing
-                    .filter(|&&(from, to)| {
-                        distances[from].signum() != distances[to].signum()
-                    })
-                    // weight middle point with distances
-                    .map(|&(from, to)| {
-                        let mut d_from = distances[from];
-                        let mut d_to = distances[to];
-
-                        if d_from > 0.0 {
-                            d_from = -d_from;
-                            d_to = -d_to;
-                        }
-
-                        let weight_from = if d_to == d_from {
-                            0.5
-                        } else {
-                            let d_diff = d_to - d_from;
-                            clamp(-d_from / d_diff, 0.0, 1.0)
-                        };
-                        lerp(corners[from], corners[to], weight_from)
-                    })
-                    .collect();
-                let p = Point3::centroid(&points);
-
-                let dist_p = shape.distance(p);
-                // let color = (p.to_vec().magnitude() * 0.85).powf(8.0);
-                // let color = 0.5 * color + 0.5 * color * clamp(dist_p.min * 1000.0, 0.0, 1.0);
-
-                raw_vbuf.push(Vertex {
-                    position: p.to_vec().cast::<f32>().to_arr(),
-                    distance_from_surface: dist_p.min as f32,
-                });
-                raw_vbuf.len() as u32 - 1
-            } else {
+            if !partially_in {
+                // FIXME
                 // This is a bit hacky, but we will never access this number
-                0
+                return None;
             }
+
+            // We want to iterate over all 12 edges of the cell. Here, we list
+            // all edges by specifying their corner indices.
+            const EDGES: [(usize, usize); 12] = [
+                // Edges whose endpoints differ in the x coordinate (first
+                // corner id is -x, second is +x).
+                (0, 4),     //    -y -z
+                (1, 5),     //    -y +z
+                (2, 6),     //    +y -z
+                (3, 7),     //    +y +z
+
+                // Edges whose endpoints differ in the y coordinate (first
+                // corner id is -y, second is +y).
+                (0, 2),     // -x    -z
+                (1, 3),     // -x    +z
+                (4, 6),     // +x    -z
+                (5, 7),     // +x    +z
+
+                // Edges whose endpoints differ in the z coordinate (first
+                // corner id is -z, second is +z).
+                (0, 1),     // -x -y
+                (2, 3),     // -x +y
+                (4, 5),     // +x -y
+                (6, 7),     // +x +y
+            ];
+
+            // Get all edge crossings. These are points where the edges of the
+            // current cell intersect the surface... more or less. We do NOT
+            // find the correct crossing point by ray marching, as this would
+            // require more queries to the shape (our current bottleneck for
+            // mandelbulb).
+            //
+            // Instead, we simply weight both endpoints of the edge by the
+            // already calculated distances. Improving this might be worth
+            // experimenting (see #1).
+            let points: Vec<_> = EDGES.iter().cloned()
+
+                // We are only interested in the edges with shape crossing. The
+                // edge crosses the shape iff the endpoints' estimated minimal
+                // distances have different signs ("minus" means: inside the
+                // shape).
+                .filter(|&(from, to)| {
+                    distances[from].signum() != distances[to].signum()
+                })
+
+                // Next, we convert the edge into a vertex on said edge. We
+                // could just use the center point of the two endpoints. But
+                // weighting each endpoint with the estimated minimal distance
+                // from the shape results in a mesh more closely representing
+                // the shape.
+                .map(|(from, to)| {
+                    // Here we want to make sure that `d_from` is  negative and
+                    // `d_to` is positive.
+                    //
+                    // Remember: we already know that both distances have
+                    // different signs!
+                    let (d_from, d_to) = if distances[from] < 0.0 {
+                        (distances[from], distances[to])
+                    } else {
+                        (-distances[from], -distances[to])
+                    };
+
+                    // This condition is only true if `d_from == -0.0`. In
+                    // theory this might happen, so we better deal with it.
+                    let weight_from = if d_to == d_from {
+                        0.5
+                    } else {
+                        // Here we calculate the weight (a number between 0 and
+                        // 1 inclusive) for the `from` endpoint. `delta` is
+                        // the difference between the two distances.
+                        //
+                        // First we will shift the distance to "the right",
+                        // making it positive. Then, we scale it by delta.
+                        //
+                        // - d_from + delta is always >= 0.0
+                        // - d_from + delta is always <= delta
+                        // ==> `(d_from + delta) / delta` is always in 0...1
+                        //
+                        // For d_from == 0 and d_to > 0:
+                        // - d_from + delta == delta
+                        // ==> result is: delta / delta == 1
+                        //
+                        // For d_from < 0 and d_to == 0:
+                        // - d_from + delta == 0
+                        // ==> result is: 0 / delta == 0
+                        let delta = d_to - d_from;
+                        (d_from + delta) / delta
+                    };
+
+                    lerp(corners[from], corners[to], weight_from)
+                })
+                .collect();
+
+            // As described in the article above, we simply use the centroid
+            // of all edge crossings.
+            let p = Point3::centroid(&points);
+
+            // Now we only calculate some meta data which might be used to
+            // color the vertex.
+            let dist_p = shape.distance(p);
+
+            raw_vbuf.push(Vertex {
+                position: p.to_vec().cast::<f32>().to_arr(),
+                distance_from_surface: dist_p.min as f32,
+            });
+            Some(raw_vbuf.len() as u32 - 1)
         });
 
+        // Third step:
+        // ===========
+        //
+        // We already have all vertices, now we need to generate the faces
+        // of our resulting mesh. For each edge crossing the surface of our
+        // shape, we will generate one face. This face's vertices are the
+        // vertices inside the four cells the edge is adjacent to.
+        //
         let mut raw_ibuf = Vec::new();
-
-        // Iterate over all edges by iterating over all points
         for (x, y, z) in cube(resolution) {
-            // Edge from this point to point in +x direction
-            if y > 0 && z > 0 && grid[(x, y, z)].signum() != grid[(x + 1, y, z)].signum()  {
-                let v0 = points[(x, y - 1, z - 1)];
-                let v1 = points[(x, y - 1, z    )];
-                let v2 = points[(x, y    , z - 1)];
-                let v3 = points[(x, y    , z    )];
+            // We iterate over all edges by iterating over all lower corners of
+            // all cells.
+            //
+            // About all those `unwrap()` calls: if the edge is crossing the
+            // surface (which is checked in the if conditions below), then we
+            // generated a vertex for all of the adjacent cells (as they,
+            // by definition, also cross the surface). So the Options we access
+            // are always `Some()`.
+
+            // Edge from the current corner pointing in +x direction
+            if y > 0 && z > 0 && dists[(x, y, z)].signum() != dists[(x + 1, y, z)].signum()  {
+                let v0 = points[(x, y - 1, z - 1)].unwrap();
+                let v1 = points[(x, y - 1, z    )].unwrap();
+                let v2 = points[(x, y    , z - 1)].unwrap();
+                let v3 = points[(x, y    , z    )].unwrap();
 
                 raw_ibuf.extend_from_slice(&[
                     v0, v1, v2,
                     v1, v2, v3,
                 ]);
             }
-            // Edge from this point to point in +y direction
-            if x > 0 && z > 0 && grid[(x, y, z)].signum() != grid[(x, y + 1, z)].signum()  {
-                let v0 = points[(x - 1, y, z - 1)];
-                let v1 = points[(x - 1, y, z    )];
-                let v2 = points[(x,     y, z - 1)];
-                let v3 = points[(x,     y, z    )];
+
+            // Edge from the current corner pointing in +y direction
+            if x > 0 && z > 0 && dists[(x, y, z)].signum() != dists[(x, y + 1, z)].signum()  {
+                let v0 = points[(x - 1, y, z - 1)].unwrap();
+                let v1 = points[(x - 1, y, z    )].unwrap();
+                let v2 = points[(x,     y, z - 1)].unwrap();
+                let v3 = points[(x,     y, z    )].unwrap();
 
                 raw_ibuf.extend_from_slice(&[
                     v0, v1, v2,
                     v1, v2, v3,
                 ]);
             }
-            // Edge from this point to point in +z direction
-            if x > 0 && y > 0 && grid[(x, y, z)].signum() != grid[(x, y, z + 1)].signum()  {
-                let v0 = points[(x - 1, y - 1, z)];
-                let v1 = points[(x - 1, y    , z)];
-                let v2 = points[(x,     y - 1, z)];
-                let v3 = points[(x,     y    , z)];
+
+            // Edge from the current corner pointing in +z direction
+            if x > 0 && y > 0 && dists[(x, y, z)].signum() != dists[(x, y, z + 1)].signum()  {
+                let v0 = points[(x - 1, y - 1, z)].unwrap();
+                let v1 = points[(x - 1, y    , z)].unwrap();
+                let v2 = points[(x,     y - 1, z)].unwrap();
+                let v3 = points[(x,     y    , z)].unwrap();
 
                 raw_ibuf.extend_from_slice(&[
                     v0, v1, v2,
@@ -182,7 +305,8 @@ impl MeshBuffer {
         }
 
         trace!(
-            "Generated {} points in box ({:?}) @ {} res",
+            "Generated {} points/{} triangles in box ({:?}) @ {} res",
+            raw_vbuf.len(),
             raw_ibuf.len() / 3,
             span,
             resolution,
@@ -195,104 +319,15 @@ impl MeshBuffer {
         }
     }
 
+    pub fn raw_vbuf(&self) -> &[Vertex] {
+        &self.raw_vbuf
+    }
+
+    pub fn raw_ibuf(&self) -> &[u32] {
+        &self.raw_ibuf
+    }
+
     pub fn resolution(&self) -> u32 {
         self.resolution
-    }
-}
-
-pub struct MeshView {
-    vbuf: VertexBuffer<Vertex>,
-    ibuf: IndexBuffer<u32>,
-    raw_buf: MeshBuffer,
-}
-
-impl MeshView {
-    pub fn from_raw_buf<F: Facade>(buf: MeshBuffer, facade: &F) -> Self {
-        let vbuf = VertexBuffer::new(facade, &buf.raw_vbuf).unwrap();
-
-        let ibuf = IndexBuffer::new(
-            facade,
-            PrimitiveType::TrianglesList,
-            &buf.raw_ibuf
-        ).unwrap();
-
-        MeshView {
-            vbuf: vbuf,
-            ibuf: ibuf,
-            raw_buf: buf,
-        }
-    }
-
-    pub fn vbuf(&self) -> &VertexBuffer<Vertex> {
-        &self.vbuf
-    }
-
-    pub fn ibuf(&self) -> &IndexBuffer<u32> {
-        &self.ibuf
-    }
-
-    pub fn raw_buf(&self) -> &MeshBuffer {
-        &self.raw_buf
-    }
-}
-
-
-#[derive(Copy, Clone)]
-pub struct Vertex {
-    position: [f32; 3],
-    distance_from_surface: f32,
-}
-
-implement_vertex!(Vertex, position, distance_from_surface);
-
-/// A lookup table for regular 3D grids. Every cell in the grid contains one
-/// value.
-///
-/// The table is structured in a way such that lookup tables for all children
-/// in an octree can easily be obtained. All data for one child is saved
-/// consecutive in memory, like so:
-///
-/// |~~~~~~~~~ -x ~~~~~~~~~||~~~~~~~~~ +x ~~~~~~~~~|
-/// |~~~ -y ~~~||~~~ +y ~~~||~~~ -y ~~~||~~~ -y ~~~|
-/// | -z || +z || -z || +z || -z || +z || -z || +z |
-///    0     1     2     3     4     5     6     7
-struct GridTable<T> {
-    size: u32,
-    data: Vec<T>,
-}
-
-impl<T> GridTable<T> {
-    fn fill_with<F>(size: u32, mut filler: F) -> Self
-        where F: FnMut(u32, u32, u32) -> T
-    {
-        assert!(size >= 2);
-
-        let mut data = Vec::with_capacity((size as usize).pow(3));
-
-        for (x, y, z) in cube(size) {
-            data.push(filler(x, y, z));
-        }
-
-        GridTable {
-            size: size,
-            data: data,
-        }
-    }
-}
-
-impl<T> Index<(u32, u32, u32)> for GridTable<T> {
-    type Output = T;
-
-    fn index(&self, (x, y, z): (u32, u32, u32)) -> &Self::Output {
-        assert!(x < self.size);
-        assert!(y < self.size);
-        assert!(z < self.size);
-
-        let idx =
-            (x as usize) * (self.size as usize).pow(2)
-            + (y as usize * self.size as usize)
-            + z as usize;
-
-        &self.data[idx]
     }
 }

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -22,8 +22,8 @@ pub struct FractalMesh<Sh> {
     program: Program,
     shape: Sh,
     thread_pool: ThreadPool,
-    new_meshes: Receiver<(Point3<f64>, MeshBuffer)>,
-    mesh_tx: Sender<(Point3<f64>, MeshBuffer)>,
+    new_meshes: Receiver<(Point3<f32>, MeshBuffer)>,
+    mesh_tx: Sender<(Point3<f32>, MeshBuffer)>,
     active_jobs: u64,
 }
 
@@ -47,10 +47,8 @@ impl<Sh: Shape + 'static + Clone> FractalMesh<Sh> {
         info!("Using {} threads to generate fractal", num_threads);
 
         // Load Shader program
-        let prog = try!(
-            load_program(facade, "point-cloud-mandelbulb")
-                .chain_err(|| "loading program for fractal mesh failed")
-        );
+        let prog = load_program(facade, "point-cloud-mandelbulb")
+            .chain_err(|| "loading program for fractal mesh failed")?;
 
         Ok(FractalMesh {
             tree: tree,
@@ -112,9 +110,9 @@ impl<Sh: Shape + 'static + Clone> FractalMesh<Sh> {
             max: u32,
         }
 
-        fn desired_resolution(p: Point3<f64>, eye: Point3<f64>) -> ResolutionQuery {
-            const PRECISION_MUTIPLIER: f64 = 150.0;
-            const MAX_RES: f64 = 250.0;
+        fn desired_resolution(p: Point3<f32>, eye: Point3<f32>) -> ResolutionQuery {
+            const PRECISION_MUTIPLIER: f32 = 150.0;
+            const MAX_RES: f32 = 250.0;
 
             let desired = 1.0/(p - eye).magnitude() * PRECISION_MUTIPLIER;
             let desired = clamp(desired, 0.0, MAX_RES);

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -9,11 +9,13 @@ use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
 use threadpool::ThreadPool;
 use util::ToArr;
 
-mod octree;
 mod buffer;
+mod octree;
+mod view;
 
 use self::octree::{Octree, SpanExt};
-use self::buffer::{MeshBuffer, MeshView};
+use self::buffer::MeshBuffer;
+use self::view::MeshView;
 
 /// Type to manage the graphical representation of the fractal. It updates the
 /// internal data depending on the camera position and resolution.
@@ -33,7 +35,7 @@ impl<Sh: Shape + 'static + Clone> FractalMesh<Sh> {
 
         // Setup empty tree and split first level to have 8 children
         let mut tree = Octree::spanning(
-            Point3::new(-1.0, -1.0, -1.0) .. Point3::new(1.0, 1.0, 1.0)
+            Point3::new(-1.2, -1.2, -1.2) .. Point3::new(1.2, 1.2, 1.2)
         );
         let _ = tree.root_mut().split();
         for mut child in tree.root_mut().into_children().unwrap() {

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -47,7 +47,7 @@ impl<Sh: Shape + 'static + Clone> FractalMesh<Sh> {
         info!("Using {} threads to generate fractal", num_threads);
 
         // Load Shader program
-        let prog = load_program(facade, "point-cloud-mandelbulb")
+        let prog = load_program(facade, "iso-surface")
             .chain_err(|| "loading program for fractal mesh failed")?;
 
         Ok(FractalMesh {

--- a/src/mesh/octree.rs
+++ b/src/mesh/octree.rs
@@ -3,19 +3,19 @@ use core::math::*;
 use arrayvec::ArrayVec;
 
 /// A box in three dimensional space that is represented by one octree node
-pub type Span = Range<Point3<f64>>;
+pub type Span = Range<Point3<f32>>;
 
 pub trait SpanExt {
-    fn center(&self) -> Point3<f64>;
-    fn contains(&self, p: Point3<f64>) -> bool;
+    fn center(&self) -> Point3<f32>;
+    fn contains(&self, p: Point3<f32>) -> bool;
 }
 
 impl SpanExt for Span {
-    fn center(&self) -> Point3<f64> {
+    fn center(&self) -> Point3<f32> {
         self.start + (self.end - self.start) / 2.0
     }
 
-    fn contains(&self, p: Point3<f64>) -> bool {
+    fn contains(&self, p: Point3<f32>) -> bool {
         let s = self.start;
         let e = self.end;
 
@@ -30,7 +30,7 @@ impl SpanExt for Span {
 /// In this application it's used to save the representation of the octant in
 /// order to allow different resolutions in different parts of space.
 pub struct Octree<T> {
-    span: Range<Point3<f64>>,
+    span: Range<Point3<f32>>,
     root: Octnode<T>,
 }
 
@@ -66,7 +66,7 @@ impl<T> Octree<T> {
 
     // }
 
-    pub fn leaf_mut_around(&mut self, p: Point3<f64>) -> NodeEntryMut<T> {
+    pub fn leaf_mut_around(&mut self, p: Point3<f32>) -> NodeEntryMut<T> {
         let mut node = self.root_mut();
         loop {
             if node.is_leaf() {
@@ -129,7 +129,7 @@ enum Octnode<T> {
 
 // ===========================================================================
 
-const SPLIT_SPAN_DIFF_AMOUNT: &'static [Vector3<f64>; 8] = &[
+const SPLIT_SPAN_DIFF_AMOUNT: &'static [Vector3<f32>; 8] = &[
     Vector3 { x: 0.0, y: 0.0, z: 0.0 },
     Vector3 { x: 0.0, y: 0.0, z: 1.0 },
     Vector3 { x: 0.0, y: 1.0, z: 0.0 },

--- a/src/mesh/view.rs
+++ b/src/mesh/view.rs
@@ -1,0 +1,41 @@
+use glium::backend::Facade;
+use glium::index::PrimitiveType;
+use glium::{VertexBuffer, IndexBuffer};
+use mesh::buffer::{MeshBuffer, Vertex};
+
+
+pub struct MeshView {
+    vbuf: VertexBuffer<Vertex>,
+    ibuf: IndexBuffer<u32>,
+    raw_buf: MeshBuffer,
+}
+
+impl MeshView {
+    pub fn from_raw_buf<F: Facade>(buf: MeshBuffer, facade: &F) -> Self {
+        let vbuf = VertexBuffer::new(facade, buf.raw_vbuf()).unwrap();
+
+        let ibuf = IndexBuffer::new(
+            facade,
+            PrimitiveType::TrianglesList,
+            buf.raw_ibuf(),
+        ).unwrap();
+
+        MeshView {
+            vbuf: vbuf,
+            ibuf: ibuf,
+            raw_buf: buf,
+        }
+    }
+
+    pub fn vbuf(&self) -> &VertexBuffer<Vertex> {
+        &self.vbuf
+    }
+
+    pub fn ibuf(&self) -> &IndexBuffer<u32> {
+        &self.ibuf
+    }
+
+    pub fn raw_buf(&self) -> &MeshBuffer {
+        &self.raw_buf
+    }
+}

--- a/src/util/gl.rs
+++ b/src/util/gl.rs
@@ -1,6 +1,7 @@
 use errors::*;
 use glium::Program;
 use glium::backend::Facade;
+use std::path::Path;
 
 pub fn load_program<F, S>(facade: &F, src: S) -> Result<Program>
     where F: Facade,
@@ -11,20 +12,21 @@ pub fn load_program<F, S>(facade: &F, src: S) -> Result<Program>
 
     const SHADER_FOLDER: &'static str = "shader";
 
+    let shader_folder = Path::new(SHADER_FOLDER);
+
     // Load vertex shader
-    let vert_path = format!("{}/{}.vert", SHADER_FOLDER, src.vert_path());
-    debug!("Loading vertex shader '{}' ...", vert_path);
+    let vert_path = shader_folder.join(src.vert_path()).with_extension("vert");
+    debug!("Loading vertex shader '{}' ...", vert_path.display());
 
     let mut vert_buf = String::new();
     File::open(vert_path).and_then(|mut f| f.read_to_string(&mut vert_buf))?;
 
     // Load fragment shader
-    let frag_path = format!("{}/{}.frag", SHADER_FOLDER, src.frag_path());
-    debug!("Loading fragment shader '{}' ...", frag_path);
+    let frag_path = shader_folder.join(src.frag_path()).with_extension("frag");
+    debug!("Loading fragment shader '{}' ...", frag_path.display());
 
     let mut frag_buf = String::new();
     File::open(frag_path).and_then(|mut f| f.read_to_string(&mut frag_buf))?;
-
 
     // Link program
     debug!("Linking program ...");
@@ -42,14 +44,15 @@ pub fn load_program<F, S>(facade: &F, src: S) -> Result<Program>
 }
 
 pub trait ShaderSource {
-    fn vert_path(&self) -> &str;
-    fn frag_path(&self) -> &str;
+    fn vert_path(&self) -> &Path;
+    fn frag_path(&self) -> &Path;
 }
+
 impl<'a> ShaderSource for &'a str {
-    fn vert_path(&self) -> &str { self }
-    fn frag_path(&self) -> &str { self }
+    fn vert_path(&self) -> &Path { Path::new(self) }
+    fn frag_path(&self) -> &Path { Path::new(self) }
 }
-impl<'a> ShaderSource for (&'a str, &'a str) {
-    fn vert_path(&self) -> &str { self.0 }
-    fn frag_path(&self) -> &str { self.1 }
+impl<V: AsRef<Path>, F: AsRef<Path>> ShaderSource for (V, F) {
+    fn vert_path(&self) -> &Path { self.0.as_ref() }
+    fn frag_path(&self) -> &Path { self.1.as_ref() }
 }

--- a/src/util/gl.rs
+++ b/src/util/gl.rs
@@ -16,14 +16,14 @@ pub fn load_program<F, S>(facade: &F, src: S) -> Result<Program>
     debug!("Loading vertex shader '{}' ...", vert_path);
 
     let mut vert_buf = String::new();
-    try!(File::open(vert_path).and_then(|mut f| f.read_to_string(&mut vert_buf)));
+    File::open(vert_path).and_then(|mut f| f.read_to_string(&mut vert_buf))?;
 
     // Load fragment shader
     let frag_path = format!("{}/{}.frag", SHADER_FOLDER, src.frag_path());
     debug!("Loading fragment shader '{}' ...", frag_path);
 
     let mut frag_buf = String::new();
-    try!(File::open(frag_path).and_then(|mut f| f.read_to_string(&mut frag_buf)));
+    File::open(frag_path).and_then(|mut f| f.read_to_string(&mut frag_buf))?;
 
 
     // Link program

--- a/src/util/grid.rs
+++ b/src/util/grid.rs
@@ -1,0 +1,54 @@
+use util::iter;
+use std::ops::Index;
+
+/// A lookup table for regular 3D grids. Every cell in the grid contains one
+/// value.
+///
+/// The table is structured in a way such that lookup tables for all children
+/// in an octree can easily be obtained. All data for one child is saved
+/// consecutive in memory, like so:
+///
+/// |~~~~~~~~~ -x ~~~~~~~~~||~~~~~~~~~ +x ~~~~~~~~~|
+/// |~~~ -y ~~~||~~~ +y ~~~||~~~ -y ~~~||~~~ -y ~~~|
+/// | -z || +z || -z || +z || -z || +z || -z || +z |
+///    0     1     2     3     4     5     6     7
+pub struct GridTable<T> {
+    size: u32,
+    data: Vec<T>,
+}
+
+impl<T> GridTable<T> {
+    pub fn fill_with<F>(size: u32, mut filler: F) -> Self
+        where F: FnMut(u32, u32, u32) -> T
+    {
+        assert!(size >= 2);
+
+        let mut data = Vec::with_capacity((size as usize).pow(3));
+
+        for (x, y, z) in iter::cube(size) {
+            data.push(filler(x, y, z));
+        }
+
+        GridTable {
+            size: size,
+            data: data,
+        }
+    }
+}
+
+impl<T> Index<(u32, u32, u32)> for GridTable<T> {
+    type Output = T;
+
+    fn index(&self, (x, y, z): (u32, u32, u32)) -> &Self::Output {
+        assert!(x < self.size);
+        assert!(y < self.size);
+        assert!(z < self.size);
+
+        let idx =
+            (x as usize) * (self.size as usize).pow(2)
+            + (y as usize * self.size as usize)
+            + z as usize;
+
+        &self.data[idx]
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -3,6 +3,7 @@ use core::math::*;
 
 pub mod gl;
 pub mod iter;
+pub mod grid;
 
 
 pub trait ToArr {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use core::math::*;
 
 pub mod gl;


### PR DESCRIPTION
This PR has essentially no effect on the running program. 

- Code cleanup
  - remove unnecessary code 
  - shorten code when possible
  - reorder to make it easier to understand
  - rename variables where appropriate
  - ...
- Comments: especially the surface nets algorithm has a bunch of comments now
- Documentation for a few more things
- Possible improvements
  - use correct path methods to concat paths
- And notably: the program uses `f32` everywhere now instead of `f64`. This, however, did not influence performance at all, as it seems. We can switch back to `f64` later when we have a good system about detecting double precision support of the GPU. 