### PR TITLE
Fix crash on click

### DIFF
--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -72,11 +72,14 @@ impl<T> Octree<T> {
     }
 
     /// Returns the leaf node which contains the point `p`.
-    pub fn leaf_around_mut(&mut self, p: Point3<f32>) -> NodeEntryMut<T> {
+    pub fn leaf_around_mut(&mut self, p: Point3<f32>) -> Option<NodeEntryMut<T>> {
         let mut node = self.root_mut();
+        if !node.span().contains(p) {
+            return None;
+        }
         loop {
             if node.is_leaf() {
-                return node;
+                return Some(node);
             } else {
                 node = node
                     .into_children()


### PR DESCRIPTION
The crash was caused by ray marching into infinity (until float precision broke) and requesting `leaf_around_mut(big_number)`. Now, there is a maximum iteration count for ray marching and we will ignore all clicks when we don't look at a point within the octree.