### PR TITLE
Improve mesh generation performance 

### DIFF
--- a/core/src/shape/mandelbulb.rs
+++ b/core/src/shape/mandelbulb.rs
@@ -80,39 +80,79 @@ impl Shape for Mandelbulb {
 /// the squaring in the original 2D mandelbrot. First we convert the point
 /// to spherical coordinates, then we rotate and convert them back.
 fn rotate(p: Point3<f32>, power: f32) -> Point3<f32> {
-    // For some integer powers there are formulas without trigonometric
-    // functions. This improves performance... maybe.
-    match power {
-        // 8.0 => {
-        //     let Point3 { x, y, z } = p;
-        //     let rxy2 = x.powf(2.0) + y.powf(2.0);
-        //     let a = 1.0 + (
-        //         z.powf(8.0)
-        //         - 28.0 * z.powf(6.0) * rxy2.powf(1.0)
-        //         + 70.0 * z.powf(4.0) * rxy2.powf(2.0)
-        //         - 28.0 * z.powf(2.0) * rxy2.powf(3.0)
-        //     ) / rxy2.powf(4.0);
+    // Handle special case (general formula is not able to handle points on
+    // the z axis).
+    if p.x == 0.0 && p.y == 0.0 {
+        let old_radius = (p - CENTER).magnitude();
+        let theta = (p.z / old_radius).acos();
 
-        //     Point3 {
-        //         x: a * (
-        //             x.powf(8.0)
-        //             - 28.0 * x.powf(6.0) * y.powf(2.0)
-        //             + 70.0 * x.powf(4.0) * y.powf(4.0)
-        //             - 28.0 * x.powf(2.0) * y.powf(6.0)
-        //             - y.powf(8.0)
-        //         ),
-        //         y: 8.0 * a * x * y * (
-        //             x.powf(6.0)
-        //             - 7.0 * x.powf(4.0) * y.powf(2.0)
-        //             + 7.0 * x.powf(2.0) * y.powf(4.0)
-        //             - y.powf(6.0)
-        //         ),
-        //         z: 8.0 * z
-        //             * rxy2.sqrt()
-        //             * (z.powf(2.0) - rxy2)
-        //             * (z.powf(4.0) - 6.0 * z.powf(2.0) * rxy2 + rxy2.powf(2.0)),
-        //     }
-        // }
+        // Scale and rotate the point
+        let new_radius = old_radius.powf(power);
+        let theta = theta * power;
+
+        // Convert back to cartesian coordinates
+        return new_radius * Point3::new(0.0, 0.0, theta.cos());
+    }
+
+
+    // For some integer powers there are formulas without trigonometric
+    // functions. This improves performance.
+    match power {
+        8.0 => {
+            let Point3 { x, y, z } = p;
+
+            // Yes we actually need to do that, LLVM won't generate optimal
+            // code here. LLVM transforms `x.powf(2)` into `x * x` but that's
+            // all. It has probably to do with floating point precision, but
+            // it's not that important for us.
+            let x2 = x * x;
+            let x4 = x2 * x2;
+            let x6 = x2 * x4;
+            let x8 = x4 * x4;
+
+            let y2 = y * y;
+            let y4 = y2 * y2;
+            let y6 = y2 * y4;
+            let y8 = y4 * y4;
+
+            let z2 = z * z;
+            let z4 = z2 * z2;
+            let z6 = z2 * z4;
+            let z8 = z4 * z4;
+
+            let rxy2 = x2 + y2;
+            let rxy4 = rxy2 * rxy2;
+            let rxy6 = rxy2 * rxy4;
+            let rxy8 = rxy4 * rxy4;
+
+            let a = 1.0 + (
+                z8
+                - 28.0 * z6 * rxy2
+                + 70.0 * z4 * rxy4
+                - 28.0 * z2 * rxy6
+            ) / rxy8;
+
+
+            Point3 {
+                x: a * (
+                    x8
+                    - 28.0 * x6 * y2
+                    + 70.0 * x4 * y4
+                    - 28.0 * x2 * y6
+                    - y8
+                ),
+                y: 8.0 * a * x * y * (
+                    x6
+                    - 7.0 * x4 * y2
+                    + 7.0 * x2 * y4
+                    - y6
+                ),
+                z: 8.0 * z
+                    * rxy2.sqrt()
+                    * (z2 - rxy2)
+                    * (z4 - 6.0 * z2 * rxy2 + rxy4),
+            }
+        }
         _ => {
             let old_radius = (p - CENTER).magnitude();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 
 // We just need this for benchmarks. Feel free to delete this line in case
 // I forget to.
-#![feature(test)]
+// #![feature(test)]
 
 #[macro_use] extern crate error_chain;
 #[macro_use] extern crate glium;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,10 @@
 // We apparently need this for `error-chain`
 #![recursion_limit = "1024"]
 
+// We just need this for benchmarks. Feel free to delete this line in case
+// I forget to.
+#![feature(test)]
+
 #[macro_use] extern crate error_chain;
 #[macro_use] extern crate glium;
 #[macro_use] extern crate log;

--- a/src/mesh/buffer.rs
+++ b/src/mesh/buffer.rs
@@ -363,40 +363,56 @@ impl MeshBuffer {
 
 
 
-mod benchi {
-    extern crate test;
+// mod benchi {
+//     extern crate test;
 
-    use self::test::Bencher;
-    use super::*;
-    use core::shape::Mandelbulb;
+//     use self::test::Bencher;
+//     use super::*;
+//     use core::shape::Mandelbulb;
 
-    #[bench]
-    fn bench_mandelbulb_10(b: &mut Bencher) {
-        let shape = Mandelbulb::classic(5, 2.5);
-        b.iter(|| MeshBuffer::generate_for_box(
-            &(Point3::new(-1.2, -1.2, -1.2) .. Point3::new(1.2, 1.2, 1.2)),
-            &shape,
-            10,
-        ))
-    }
+//     #[bench]
+//     fn bench_mandelbulb_10(b: &mut Bencher) {
+//         let shape = Mandelbulb::classic(5, 2.5);
+//         b.iter(|| MeshBuffer::generate_for_box(
+//             &(Point3::new(-1.2, -1.2, -1.2) .. Point3::new(1.2, 1.2, 1.2)),
+//             &shape,
+//             10,
+//         ))
+//     }
 
-    #[bench]
-    fn bench_mandelbulb_25(b: &mut Bencher) {
-        let shape = Mandelbulb::classic(5, 2.5);
-        b.iter(|| MeshBuffer::generate_for_box(
-            &(Point3::new(-1.2, -1.2, -1.2) .. Point3::new(1.2, 1.2, 1.2)),
-            &shape,
-            25,
-        ))
-    }
+//     // #[bench]
+//     // fn bench_mandelbulb_25(b: &mut Bencher) {
+//     //     let shape = Mandelbulb::classic(5, 2.5);
+//     //     b.iter(|| MeshBuffer::generate_for_box(
+//     //         &(Point3::new(-1.2, -1.2, -1.2) .. Point3::new(1.2, 1.2, 1.2)),
+//     //         &shape,
+//     //         25,
+//     //     ))
+//     // }
 
-    #[bench]
-    fn bench_mandelbulb_50(b: &mut Bencher) {
-        let shape = Mandelbulb::classic(5, 2.5);
-        b.iter(|| MeshBuffer::generate_for_box(
-            &(Point3::new(-1.2, -1.2, -1.2) .. Point3::new(1.2, 1.2, 1.2)),
-            &shape,
-            50,
-        ))
-    }
-}
+//     // #[bench]
+//     // fn bench_mandelbulb_50(b: &mut Bencher) {
+//     //     let shape = Mandelbulb::classic(5, 2.5);
+//     //     b.iter(|| MeshBuffer::generate_for_box(
+//     //         &(Point3::new(-1.2, -1.2, -1.2) .. Point3::new(1.2, 1.2, 1.2)),
+//     //         &shape,
+//     //         50,
+//     //     ))
+//     // }
+
+//     #[bench]
+//     fn classic_5(b: &mut Bencher) {
+//         let shape = Mandelbulb::classic(5, 2.5);
+//         let points = [
+//             Point3::new(0.0, 0.0, 0.0),
+//             Point3::new(1.0, 0.0, 0.0),
+//             Point3::new(0.0, 1.0, 0.0),
+//             Point3::new(0.0, 0.0, 1.0),
+//             Point3::new(0.3, 0.3, 0.4),
+//         ];
+
+//         b.iter(|| {
+//             points.iter().map(|&p| shape.min_distance_from(p)).sum::<f32>()
+//         })
+//     }
+// }

--- a/src/mesh/buffer.rs
+++ b/src/mesh/buffer.rs
@@ -1,9 +1,12 @@
+use std::time::Instant;
+
 use core::math::*;
 use core::Shape;
 use octree::Span;
 use util::ToArr;
 use util::iter::cube;
 use util::grid::GridTable;
+use util::time::DurationExt;
 
 
 #[derive(Copy, Clone)]
@@ -61,7 +64,7 @@ impl MeshBuffer {
             span.start + -overflow .. span.end + overflow
         };
 
-        trace!("Starting to generate in {:?} @ {} res", span, resolution);
+        let before_first = Instant::now();
 
         // First Step:
         // ===========
@@ -75,6 +78,8 @@ impl MeshBuffer {
 
             shape.min_distance_from(p)
         });
+
+        let before_second = Instant::now();
 
 
         // Second Step:
@@ -259,6 +264,9 @@ impl MeshBuffer {
             Some(raw_vbuf.len() as u32 - 1)
         });
 
+        let before_third = Instant::now();
+
+
         // Third step:
         // ===========
         //
@@ -318,12 +326,17 @@ impl MeshBuffer {
             }
         }
 
+        let after_third = Instant::now();
+
+
         trace!(
-            "Generated {} points/{} triangles in box ({:?}) @ {} res",
+            "Generated {:5} points, {:5} triangles in {:9} ({:9}, {:9}, {:9})",
             raw_vbuf.len(),
             raw_ibuf.len() / 3,
-            span,
-            resolution,
+            (after_third - before_first).display_ms(),
+            (before_second - before_first).display_ms(),
+            (before_third - before_second).display_ms(),
+            (after_third - before_third).display_ms(),
         );
 
         MeshBuffer {
@@ -345,4 +358,45 @@ impl MeshBuffer {
     // pub fn resolution(&self) -> u32 {
     //     self.resolution
     // }
+}
+
+
+
+
+mod benchi {
+    extern crate test;
+
+    use self::test::Bencher;
+    use super::*;
+    use core::shape::Mandelbulb;
+
+    #[bench]
+    fn bench_mandelbulb_10(b: &mut Bencher) {
+        let shape = Mandelbulb::classic(5, 2.5);
+        b.iter(|| MeshBuffer::generate_for_box(
+            &(Point3::new(-1.2, -1.2, -1.2) .. Point3::new(1.2, 1.2, 1.2)),
+            &shape,
+            10,
+        ))
+    }
+
+    #[bench]
+    fn bench_mandelbulb_25(b: &mut Bencher) {
+        let shape = Mandelbulb::classic(5, 2.5);
+        b.iter(|| MeshBuffer::generate_for_box(
+            &(Point3::new(-1.2, -1.2, -1.2) .. Point3::new(1.2, 1.2, 1.2)),
+            &shape,
+            25,
+        ))
+    }
+
+    #[bench]
+    fn bench_mandelbulb_50(b: &mut Bencher) {
+        let shape = Mandelbulb::classic(5, 2.5);
+        b.iter(|| MeshBuffer::generate_for_box(
+            &(Point3::new(-1.2, -1.2, -1.2) .. Point3::new(1.2, 1.2, 1.2)),
+            &shape,
+            50,
+        ))
+    }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -3,6 +3,7 @@ use core::math::*;
 pub mod gl;
 pub mod iter;
 pub mod grid;
+pub mod time;
 
 
 pub trait ToArr {

--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -1,0 +1,24 @@
+use std::time::Duration;
+use std::fmt;
+
+pub trait DurationExt {
+    fn display_ms(&self) -> DisplayMs;
+}
+
+impl DurationExt for Duration {
+    fn display_ms(&self) -> DisplayMs {
+        DisplayMs(*self)
+    }
+}
+
+pub struct DisplayMs(Duration);
+
+impl fmt::Display for DisplayMs {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let secs = self.0.as_secs();
+        let nanos = self.0.subsec_nanos();
+
+        let ms = (secs as f64) * 1000.0 + ((nanos / 1000) as f64 / 1000.0);
+        format!("{}ms", ms).fmt(f)
+    }
+}


### PR DESCRIPTION
This implements the power 8 version of the non-trigonometric mandelbulb DE (see #17). It roughly doubles the speed of mesh generation (and the DE itself, as mesh generation's bottleneck is the DE).